### PR TITLE
Support for the MH-ET LIVE MiniKit ESP32

### DIFF
--- a/Dice-Tower/Dice-Tower.ino
+++ b/Dice-Tower/Dice-Tower.ino
@@ -6,7 +6,7 @@
  * Github                 : https://github.com/Joennuh/Dice-Tower
  * Wiki                   : https://github.com/Joennuh/Dice-Tower/wiki
  * 
- * This sketch is meant for a Dice Tower. It is a sketch for a Wemos D1 mini or a MH TK LIVE MiniKit ESP32.
+ * This sketch is meant for a Dice Tower. It is a sketch for a Wemos D1 mini or a MH-ET LIVE MiniKit ESP32.
  * It drives 2 red leds for the eyes of a skull and 3 leds for a campfire. Also there is 1 button to
  * initiate blinking eyes and 1 button to toggle between steady or flickering / blinking lights.
  * Although it is developed for WiFi capable Arduino boards the WiFi capabilities aren't used.
@@ -30,8 +30,8 @@
  * -  Button2: https://github.com/LennartHennigs/Button2
  * And probably I've forgotten to mention sources. In that case: I'm sorry for that.
  * 
- * Hardware configuration (after the slash are the GPIO pins on MH TK LIVE MiniKit ESP32):
- * - Wemos D1 mini / MH TK LIVE MiniKit ESP32
+ * Hardware configuration (after the slash are the GPIO pins on MH-ET LIVE MiniKit ESP32):
+ * - Wemos D1 mini / MH-ET LIVE MiniKit ESP32
  * - 3 yellow leds (each attached with 100R resistor to D6, D7 and D8 / 19, 23 and 5)
  * - 2 red leds (each attached with 100R resistor to D1 and D2 / 22 and 21)
  * - 1 button (attached with external 4,7K pull-up resistor to D5 / 18)
@@ -49,7 +49,7 @@
 // You can change the values of this defines but it is advisable to not do this.
 
 #ifdef ESP32
-// Define pin assignment for MH TK LIVE MiniKit ESP32
+// Define pin assignment for MH-ET LIVE MiniKit ESP32
 #define LED_CONFIG 26
 #define LED_EYE1 22
 #define LED_EYE2 21
@@ -76,7 +76,7 @@
 // These settings can be change to your own needs.
 
 #ifdef ESP32
-// Setting PWM properties (only for MH TK LIVE MiniKit ESP32)
+// Setting PWM properties (only for MH-ET LIVE MiniKit ESP32)
 const int pwmFreq = 5000;
 const int pwmResolution = 8;
 #endif
@@ -91,7 +91,7 @@ const int eyeBlinkShortOff = 100; // Duration of the off state while blinking. I
 const int eyeBlinkAmount = 3; // How much blinks of the eyes during the blink state on a detected dice.
 
 #ifdef ESP32
-// Define PWM channel for MH TK LIVE MiniKit ESP32
+// Define PWM channel for MH-ET LIVE MiniKit ESP32
 const int pwmEyesChannel = 0;
 #endif
 
@@ -102,7 +102,7 @@ const unsigned long fireFlickeringSpeed = 75; // Interval in milliseconds before
 
 
 #ifdef ESP32
-// Define PWM channel for for MH TK LIVE MiniKit ESP32
+// Define PWM channel for for MH-ET LIVE MiniKit ESP32
 const int pwmFire1Channel = 1;
 const int pwmFire2Channel = 2;
 const int pwmFire3Channel = 3;
@@ -117,7 +117,7 @@ const int configLedDoubleClickDurationOff = 200; // How long in milliseconds sho
 // == CONFIGURATION =======================================================================================
 // These settings are needed to let the sketch work correctly but should not be changed!
 
-Button2 btnTrigger(BTN_TRIGGER, INPUT_PULLUP,1); // Activate internal pull-up resistor of Wemos D1 mini pin D3 / MH TK LIVE MiniKit ESP32 pin 17
+Button2 btnTrigger(BTN_TRIGGER, INPUT_PULLUP,1); // Activate internal pull-up resistor of Wemos D1 mini pin D3 / MH-ET LIVE MiniKit ESP32 pin 17
 Button2 btnConfig(BTN_CONFIG); // Uses external 4,7K pull-up resistor
 
 bool eyesOn = false; // Trigger for within the loop to turn the eyes on.

--- a/Dice-Tower/Dice-Tower.ino
+++ b/Dice-Tower/Dice-Tower.ino
@@ -6,10 +6,10 @@
  * Github                 : https://github.com/Joennuh/Dice-Tower
  * Wiki                   : https://github.com/Joennuh/Dice-Tower/wiki
  * 
- * This sketch is meant for a Dice Tower. It is a sketch for a Wemos D1 mini. It drives 2 red leds for
- * the eyes of a skull and 3 leds for a campfire. Also there is 1 button to initiate blinking eyes and
- * 1 button to toggle between steady or flickering / blinking lights.
- * Although it is developed for a WiFi capable Arduino board the WiFi capabilities aren't used.
+ * This sketch is meant for a Dice Tower. It is a sketch for a Wemos D1 mini or a MH TK LIVE MiniKit ESP32.
+ * It drives 2 red leds for the eyes of a skull and 3 leds for a campfire. Also there is 1 button to
+ * initiate blinking eyes and 1 button to toggle between steady or flickering / blinking lights.
+ * Although it is developed for WiFi capable Arduino boards the WiFi capabilities aren't used.
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,12 +30,12 @@
  * -  Button2: https://github.com/LennartHennigs/Button2
  * And probably I've forgotten to mention sources. In that case: I'm sorry for that.
  * 
- * Hardware configuration:
- * - Wemos D1 mini
- * - 3 yellow leds (each attached with 100R resistor to D6, D7 and D8)
- * - 2 red leds (each attached with 100R resistor to D1 and D2)
- * - 1 button (attached with external 4,7K pull-up resistor to D5)
- * - 1 any kind of switch to trigger blinking eyes (attached to D3)
+ * Hardware configuration (after the slash are the GPIO pins on MH TK LIVE MiniKit ESP32):
+ * - Wemos D1 mini / MH TK LIVE MiniKit ESP32
+ * - 3 yellow leds (each attached with 100R resistor to D6, D7 and D8 / 19, 23 and 5)
+ * - 2 red leds (each attached with 100R resistor to D1 and D2 / 22 and 21)
+ * - 1 button (attached with external 4,7K pull-up resistor to D5 / 18)
+ * - 1 any kind of switch to trigger blinking eyes (attached to D3 / 17)
 ************************************************************************************************************/
 // Sketch metadata. Please do not change the following lines unless you plan to release an fork. In that case please add some information about you to these lines.
 #define PROG_NAME "Dice Tower"
@@ -117,7 +117,7 @@ const int configLedDoubleClickDurationOff = 200; // How long in milliseconds sho
 // == CONFIGURATION =======================================================================================
 // These settings are needed to let the sketch work correctly but should not be changed!
 
-Button2 btnTrigger(BTN_TRIGGER, INPUT_PULLUP,1); // Activate internal pull-up resistor of Wemos D1 mini pin D3
+Button2 btnTrigger(BTN_TRIGGER, INPUT_PULLUP,1); // Activate internal pull-up resistor of Wemos D1 mini pin D3 / MH TK LIVE MiniKit ESP32 pin 17
 Button2 btnConfig(BTN_CONFIG); // Uses external 4,7K pull-up resistor
 
 bool eyesOn = false; // Trigger for within the loop to turn the eyes on.

--- a/Dice-Tower/Dice-Tower.ino
+++ b/Dice-Tower/Dice-Tower.ino
@@ -58,6 +58,7 @@
 #define LED_FIRE3 5
 #define BTN_TRIGGER 17
 #define BTN_CONFIG 18
+#define ANALOG_RANDOMSEED 36 // Leave this pin unconnected, the noise of this pin is used for the random creator
 #else
 // Define pin assignment for Wemos D1 mini
 #define LED_CONFIG D0
@@ -68,6 +69,7 @@
 #define LED_FIRE3 D8
 #define BTN_TRIGGER D3
 #define BTN_CONFIG D5
+#define ANALOG_RANDOMSEED A0 // Leave this pin unconnected, the noise of this pin is used for the random creator
 #endif
 
 // == SETTINGS ============================================================================================
@@ -133,6 +135,15 @@ int configLedType = 0; // The sequence how the configuration led should turn on.
 unsigned long configLedTimestamp = millis(); // Record default timestamp for the configuration led logic.
 int configLedDoubleClickstate = 0; // Set the initial state for the blinking configuration led logic. In this case the blink starts with the off (0) state.
 int configLedDoubleClickCount = 2; // Set the counter (which got decreased) for the amount of blinks for the configuration led after a double click.
+
+// Set active states for LED_BUILTIN. On ESP8266 the led is active on LOW, but on ESP32 it is active on HIGH.
+#ifdef ESP32
+#define ONBOARD_ON HIGH
+#define ONBOARD_OFF LOW
+#else
+#define ONBOARD_ON LOW
+#define ONBOARD_OFF HIGH
+#endif
 
 // == BUTTON HANDLING =====================================================================================
 // The following function sets the handlers for all button presses.
@@ -233,15 +244,17 @@ void setup() {
   // Intialize buttons
   button_init();
 
+// -- ONBOARD LED -----------------------------------------------------------------------------------------
   // Initialize onboard led, test it and leave it on until fully booted
   Serial.print("Configure onboard led... ");
   pinMode(LED_BUILTIN,OUTPUT);
   Serial.println("DONE");
   Serial.print("Turning onboard led on...");
-  digitalWrite(LED_BUILTIN,LOW); // Onboard led is active low
+  digitalWrite(LED_BUILTIN,ONBOARD_ON);
   Serial.println("DONE");
   delay(500);
 
+// -- CONFIG LED ------------------------------------------------------------------------------------------
    // Initialize config led, test it and turn it off
   Serial.print("Configure config led... ");
   pinMode(LED_CONFIG, OUTPUT);
@@ -254,21 +267,22 @@ void setup() {
   digitalWrite(LED_CONFIG, LOW);
   Serial.println("DONE");
 
+// -- EYE LEDS --------------------------------------------------------------------------------------------
 #ifdef ESP32
   // With the lack of analogWrite() function for ESP32 use PWM with the ledc... functions on MH TH LIVE MiniKit ESP32
   Serial.print("Configure PWM channel for leds for eyes... ");
   ledcSetup(pwmEyesChannel, pwmFreq, pwmResolution);
   Serial.println("DONE");
   
-  Serial.print("Attach eye 1 to PWM channel for eyes... ");
+  Serial.print("Attach led eye 1 to PWM channel for eyes... ");
   ledcAttachPin(LED_EYE1, pwmEyesChannel);
   Serial.println("DONE");
   
-  Serial.print("Attach eye 2 to PWM channel for eyes... ");
+  Serial.print("Attach led eye 2 to PWM channel for eyes... ");
   ledcAttachPin(LED_EYE2, pwmEyesChannel);
   Serial.println("DONE");
 
-  Serial.print("Turning both eyes on... ");
+  Serial.print("Turning both eye leds on... ");
   ledcWrite(pwmEyesChannel, 255);
   Serial.println("DONE");
 
@@ -290,7 +304,7 @@ void setup() {
   Serial.print("Turning led eye 1 off... ");
   analogWrite(LED_EYE1, 0);
   Serial.println("DONE");
-#endif
+
   // Initialize eye 2, test it and turn it off
   Serial.print("Configure led eye 2... ");
   pinMode(LED_EYE2, OUTPUT);
@@ -302,7 +316,31 @@ void setup() {
   Serial.print("Turning led eye 2 off... ");
   analogWrite(LED_EYE2, 0);
   Serial.println("DONE");
+#endif
 
+// -- FIRE 1 LED ------------------------------------------------------------------------------------------
+#ifdef ESP32
+  // With the lack of analogWrite() function for ESP32 use PWM with the ledc... functions on MH TH LIVE MiniKit ESP32
+  Serial.print("Configure PWM channel for led fire 1... ");
+  ledcSetup(pwmFire1Channel, pwmFreq, pwmResolution);
+  Serial.println("DONE");
+  
+  Serial.print("Attach led fire 1 to PWM channel for eyes... ");
+  ledcAttachPin(LED_FIRE1, pwmFire1Channel);
+  Serial.println("DONE");
+
+  Serial.print("Turning led fire 1 on... ");
+  ledcWrite(pwmFire1Channel, 255);
+  Serial.println("DONE");
+
+  delay(500);
+
+  Serial.print("Turning led fire 1 off... ");
+  ledcWrite(pwmFire1Channel, 0);
+  Serial.println("DONE");
+  
+#else
+  // For Wemos D1 mini we can use analogWrite()
   // Initialize fire 1, test it and turn it off
   Serial.print("Configure led fire 1... ");
   pinMode(LED_FIRE1, OUTPUT);
@@ -314,7 +352,31 @@ void setup() {
   Serial.print("Turning led fire 1 off... ");
   analogWrite(LED_FIRE1, 0);
   Serial.println("DONE");
+#endif
 
+// -- FIRE 2 LED ------------------------------------------------------------------------------------------
+#ifdef ESP32
+  // With the lack of analogWrite() function for ESP32 use PWM with the ledc... functions on MH TH LIVE MiniKit ESP32
+  Serial.print("Configure PWM channel for led fire 2... ");
+  ledcSetup(pwmFire2Channel, pwmFreq, pwmResolution);
+  Serial.println("DONE");
+  
+  Serial.print("Attach led fire 2 to PWM channel for eyes... ");
+  ledcAttachPin(LED_FIRE2, pwmFire2Channel);
+  Serial.println("DONE");
+
+  Serial.print("Turning led fire 2 on... ");
+  ledcWrite(pwmFire2Channel, 255);
+  Serial.println("DONE");
+
+  delay(500);
+
+  Serial.print("Turning led fire 2 off... ");
+  ledcWrite(pwmFire2Channel, 0);
+  Serial.println("DONE");
+  
+#else
+  // For Wemos D1 mini we can use analogWrite()
   // Initialize fire 2, test it and turn it off
   Serial.print("Configure led fire 2... ");
   pinMode(LED_FIRE2, OUTPUT);
@@ -326,7 +388,31 @@ void setup() {
   Serial.print("Turning led fire 2 off... ");
   analogWrite(LED_FIRE2, 0);
   Serial.println("DONE");
+#endif
 
+// -- FIRE 3 LED ------------------------------------------------------------------------------------------
+#ifdef ESP32
+  // With the lack of analogWrite() function for ESP32 use PWM with the ledc... functions on MH TH LIVE MiniKit ESP32
+  Serial.print("Configure PWM channel for led fire 3... ");
+  ledcSetup(pwmFire3Channel, pwmFreq, pwmResolution);
+  Serial.println("DONE");
+  
+  Serial.print("Attach led fire 3 to PWM channel for eyes... ");
+  ledcAttachPin(LED_FIRE3, pwmFire3Channel);
+  Serial.println("DONE");
+
+  Serial.print("Turning led fire 3 on... ");
+  ledcWrite(pwmFire3Channel, 255);
+  Serial.println("DONE");
+
+  delay(500);
+
+  Serial.print("Turning led fire 3 off... ");
+  ledcWrite(pwmFire3Channel, 0);
+  Serial.println("DONE");
+  
+#else
+  // For Wemos D1 mini we can use analogWrite()
   // Initialize fire 3, test it and turn it off
   Serial.print("Configure led fire 3... ");
   pinMode(LED_FIRE3, OUTPUT);
@@ -338,15 +424,18 @@ void setup() {
   Serial.print("Turning led fire 3 off... ");
   analogWrite(LED_FIRE3, 0);
   Serial.println("DONE");
+#endif
 
+// -- RANDOM CREATOR --------------------------------------------------------------------------------------
   // Feeding randomSeed with random analog noise of unconnected analog pin... 
   Serial.print("Feeding randomSeed with random analog noise of unconnected analog pin... ");
-  randomSeed(analogRead(A0));
+  randomSeed(analogRead(ANALOG_RANDOMSEED));
   Serial.println("DONE");
 
+// -- TURNING ONBOARD LED OFF -----------------------------------------------------------------------------
   // Turning onboard led off
   Serial.print("Turning onboard led off... ");
-  digitalWrite(LED_BUILTIN,HIGH);
+  digitalWrite(LED_BUILTIN,ONBOARD_OFF);
   Serial.println("DONE");
 
   Serial.println("- READY -");
@@ -431,9 +520,17 @@ void loop() {
   // Permamently lit fire
   if(stableLight == true)
   {
+#ifdef ESP32
+    // With the lack of analogWrite() function for ESP32 use PWM with the ledc... functions on MH TH LIVE MiniKit ESP32
+    ledcWrite(pwmFire1Channel, fireMaxIntensity);
+    ledcWrite(pwmFire2Channel, fireMaxIntensity);
+    ledcWrite(pwmFire3Channel, fireMaxIntensity);
+#else
+    // For Wemos D1 mini we can use analogWrite()
     analogWrite(LED_FIRE1, fireMaxIntensity);
     analogWrite(LED_FIRE2, fireMaxIntensity);
     analogWrite(LED_FIRE3, fireMaxIntensity);
+#endif
   }
   // Flickering fire
   else
@@ -443,9 +540,17 @@ void loop() {
       int randFire1 = random(fireMinIntensity,fireMaxIntensity);
       int randFire2 = random(fireMinIntensity,fireMaxIntensity);
       int randFire3 = random(fireMinIntensity,fireMaxIntensity);
+#ifdef ESP32
+      // With the lack of analogWrite() function for ESP32 use PWM with the ledc... functions on MH TH LIVE MiniKit ESP32
+      ledcWrite(pwmFire1Channel, randFire1);
+      ledcWrite(pwmFire2Channel, randFire2);
+      ledcWrite(pwmFire3Channel, randFire3);
+#else
+      // For Wemos D1 mini we can use analogWrite()
       analogWrite(LED_FIRE1, randFire1);
       analogWrite(LED_FIRE2, randFire2);
       analogWrite(LED_FIRE3, randFire3);
+#endif
       fireTimestamp = millis();
     }
   }
@@ -456,16 +561,22 @@ void loop() {
     // Within duration set in the settings
     if(millis() - eyesStartTimestamp < eyeActiveDuration)
     {
-        digitalWrite(LED_BUILTIN,LOW);
+        digitalWrite(LED_BUILTIN,ONBOARD_ON);
 
         // Permamently lit eyes
         if(stableLight==true)
         {
           Serial.println("Stable light is activated so not blinking. Just stable lit eyes.");
+#ifdef ESP32
+          // With the lack of analogWrite() function for ESP32 use PWM with the ledc... functions on MH TH LIVE MiniKit ESP32
+          ledcWrite(pwmEyesChannel, eyeActiveIntensity);
+#else
+          // For Wemos D1 mini we can use analogWrite()
           analogWrite(LED_EYE1,eyeActiveIntensity);
           analogWrite(LED_EYE2,eyeActiveIntensity);
+#endif
         }
-        // Blinkling eyes
+        // Blinking eyes
         else
         {       
             Serial.print("eyeBlinkCount: ");
@@ -492,8 +603,14 @@ void loop() {
                     if(millis() - blinkShortTimestamp <= eyeBlinkShortOn)
                     {
                         Serial.println("blinkShortTimestamp <= eyeBlinkShortOn");
+#ifdef ESP32
+                        // With the lack of analogWrite() function for ESP32 use PWM with the ledc... functions on MH TH LIVE MiniKit ESP32
+                        ledcWrite(pwmEyesChannel, eyeActiveIntensity);
+#else
+                        // For Wemos D1 mini we can use analogWrite()
                         analogWrite(LED_EYE1,eyeActiveIntensity);
                         analogWrite(LED_EYE2,eyeActiveIntensity);
+#endif
                     }
                     else{
                         Serial.println("blinkShortTimestamp > eyeBlinkShortOn >> Set eyeBlinkShortState to 0 and reset timestamp");
@@ -507,8 +624,14 @@ void loop() {
                     if(millis() - blinkShortTimestamp <= eyeBlinkShortOff)
                     {
                         Serial.println("blinkShortTimestamp <= eyeBlinkShortOff");
+#ifdef ESP32
+                        // With the lack of analogWrite() function for ESP32 use PWM with the ledc... functions on MH TH LIVE MiniKit ESP32
+                        ledcWrite(pwmEyesChannel, eyeIdleIntensity);
+#else
+                        // For Wemos D1 mini we can use analogWrite()
                         analogWrite(LED_EYE1,eyeIdleIntensity);
                         analogWrite(LED_EYE2,eyeIdleIntensity);
+#endif
                     }
                     else{
                         Serial.println("blinkShortTimestamp > eyeBlinkShortOff >> Set eyeBlinkShortState to 1, decrease eyeBlinkCount and reset timestamp");
@@ -522,8 +645,14 @@ void loop() {
             else
             {
                 Serial.println("Eyes continously on");
+#ifdef ESP32
+                // With the lack of analogWrite() function for ESP32 use PWM with the ledc... functions on MH TH LIVE MiniKit ESP32
+                ledcWrite(pwmEyesChannel, eyeActiveIntensity);
+#else
+                // For Wemos D1 mini we can use analogWrite()
                 analogWrite(LED_EYE1,eyeActiveIntensity);
                 analogWrite(LED_EYE2,eyeActiveIntensity);
+#endif
             }
         }      
     }
@@ -538,8 +667,14 @@ void loop() {
   // No dice detected. Keeping eyes dim.
   else
   {
-    digitalWrite(LED_BUILTIN,HIGH);
+    digitalWrite(LED_BUILTIN,ONBOARD_OFF);
+#ifdef ESP32
+    // With the lack of analogWrite() function for ESP32 use PWM with the ledc... functions on MH TH LIVE MiniKit ESP32
+    ledcWrite(pwmEyesChannel, eyeIdleIntensity);
+#else
+    // For Wemos D1 mini we can use analogWrite()
     analogWrite(LED_EYE1,eyeIdleIntensity);
     analogWrite(LED_EYE2,eyeIdleIntensity);
+#endif
   }
 }

--- a/Dice-Tower/Dice-Tower.ino
+++ b/Dice-Tower/Dice-Tower.ino
@@ -48,6 +48,18 @@
 // == DEFINES =============================================================================================
 // You can change the values of this defines but it is advisable to not do this.
 
+#ifdef ESP32
+// Define pin assignment for MH TK LIVE MiniKit ESP32
+#define LED_CONFIG 26
+#define LED_EYE1 22
+#define LED_EYE2 21
+#define LED_FIRE1 19
+#define LED_FIRE2 23
+#define LED_FIRE3 5
+#define BTN_TRIGGER 17
+#define BTN_CONFIG 18
+#else
+// Define pin assignment for Wemos D1 mini
 #define LED_CONFIG D0
 #define LED_EYE1 D1
 #define LED_EYE2 D2
@@ -56,9 +68,16 @@
 #define LED_FIRE3 D8
 #define BTN_TRIGGER D3
 #define BTN_CONFIG D5
+#endif
 
 // == SETTINGS ============================================================================================
 // These settings can be change to your own needs.
+
+#ifdef ESP32
+// Setting PWM properties (only for MH TK LIVE MiniKit ESP32)
+const int pwmFreq = 5000;
+const int pwmResolution = 8;
+#endif
 
 // EYE LEDS
 const int eyeIdleIntensity = 20; // Idle intensity for the eyes on a scale of 0 to 255
@@ -69,10 +88,23 @@ const int eyeBlinkShortOn = 100; // Duration of the on state while blinking. In 
 const int eyeBlinkShortOff = 100; // Duration of the off state while blinking. In milliseconds.
 const int eyeBlinkAmount = 3; // How much blinks of the eyes during the blink state on a detected dice.
 
+#ifdef ESP32
+// Define PWM channel for MH TK LIVE MiniKit ESP32
+const int pwmEyesChannel = 0;
+#endif
+
 // FIRE LEDS
 const int fireMinIntensity = 0; // Minimum intensity for campfire flickering on a scale of 0 - 255.
 const int fireMaxIntensity = 255; // Maximum intensity for campfire flickering on a scale of 0 - 255
 const unsigned long fireFlickeringSpeed = 75; // Interval in milliseconds before a new random intensity will be set for a campfire led.
+
+
+#ifdef ESP32
+// Define PWM channel for for MH TK LIVE MiniKit ESP32
+const int pwmFire1Channel = 1;
+const int pwmFire2Channel = 2;
+const int pwmFire3Channel = 3;
+#endif
 
 // CONFIGURATION LED
 const int configLedSingleClickDurationOn = 200; // How long in milliseconds should the configuration led stay on after a single click on the configuration button.
@@ -222,6 +254,31 @@ void setup() {
   digitalWrite(LED_CONFIG, LOW);
   Serial.println("DONE");
 
+#ifdef ESP32
+  // With the lack of analogWrite() function for ESP32 use PWM with the ledc... functions on MH TH LIVE MiniKit ESP32
+  Serial.print("Configure PWM channel for leds for eyes... ");
+  ledcSetup(pwmEyesChannel, pwmFreq, pwmResolution);
+  Serial.println("DONE");
+  
+  Serial.print("Attach eye 1 to PWM channel for eyes... ");
+  ledcAttachPin(LED_EYE1, pwmEyesChannel);
+  Serial.println("DONE");
+  
+  Serial.print("Attach eye 2 to PWM channel for eyes... ");
+  ledcAttachPin(LED_EYE2, pwmEyesChannel);
+  Serial.println("DONE");
+
+  Serial.print("Turning both eyes on... ");
+  ledcWrite(pwmEyesChannel, 255);
+  Serial.println("DONE");
+
+  delay(500);
+
+  Serial.print("Turning both eyes off... ");
+  ledcWrite(pwmEyesChannel, 0);
+  Serial.println("DONE");
+#else
+  // For Wemos D1 mini we can use analogWrite()
   // Initialize eye 1, test it and turn it off
   Serial.print("Configure led eye 1... ");
   pinMode(LED_EYE1, OUTPUT);
@@ -233,7 +290,7 @@ void setup() {
   Serial.print("Turning led eye 1 off... ");
   analogWrite(LED_EYE1, 0);
   Serial.println("DONE");
-
+#endif
   // Initialize eye 2, test it and turn it off
   Serial.print("Configure led eye 2... ");
   pinMode(LED_EYE2, OUTPUT);

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 **Create some interaction effects for your homemade Dice Tower.**
 
 ![ESP8266](https://img.shields.io/badge/ESP-8266-000000.svg?longCache=true&style=flat&colorA=CC101F)
+![ESP32](https://img.shields.io/badge/ESP-32-000000.svg?longCache=true&style=flat&colorA=CC101F)
 [![GitHub license](https://img.shields.io/github/license/Joennuh/Dice-Tower)](https://github.com/Joennuh/Dice-Tower/blob/master/LICENSE)
 ![GitHub repo size](https://img.shields.io/github/repo-size/Joennuh/Dice-Tower)
 ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/Joennuh/Dice-Tower/master)
@@ -18,28 +19,29 @@ Nico doesn't have the knowledge of the electronics and programming. The more I e
 Nico wanted to build a Dice Tower which have a kind of skull on the front of the tower. In that skulls there will be placed 2 red leds as eyes which should blink when a dice is put in the tower. Then he wanted a campfire somehere on the object. This will be simmulated with 3 yellow leds (lights up as orange in my opinion). Then he wants to connect 4 miniature lanterns which should be permanantly lit. And finally he also wants to put 20 cold white leds in the tower which also should be lit permanently.
 
 The things I added to the ideas of my colleague:
-- A Wemos D1 mini to add interaction and animation effects to the Dice Tower.
+- A Wemos D1 mini to add interaction and animation effects to the Dice Tower. Later on in the project I added support for the MH-ET LIVE MiniKit ESP32 which has exactly the same pin layout as the Wemos D1 mini but had ESP32 onboard instead of ESP8266 plus extra pins.
 - A SW-18010P vibration sensor to detect the dice rolling through the tube of the Dice Tower.
 - A configuration button.
 - A configuration light (indicates whether a button press has been fetched or provide the status of things going on).
 - A power-light to see whether the project gets powered correctly.
-- A nice PCB design to flatten the space needed to drive all the leds. The original idea consisted of a main board with all connections to the leds soldered on it, then put a "interactive module" on top of that and at last a Wemos D1 mini on top of that. With a nice own designed PCB we got 1 layer less.
+- A nice PCB design to flatten the space needed to drive all the leds. The original idea consisted of a main board with all connections to the leds soldered on it, then put a "interactive module" on top of that and at last a Wemos D1 mini or MH-ET LIVE MiniKit ESP32 on top of that. With a nice own designed PCB we got 1 layer less.
 
 ## Materials
 ### PCB
-Ofcourse you can build the project on a prototype board but if you want a nice looking PCB you can let a PCB manafacturer create it. I have designed a PCB at [EasyEDA](https://www.easyeda.com). You can find it here: <https://easyeda.com/Joennuh/Dice-Tower>
+Ofcourse you can build the project on a prototype board but if you want a nice looking PCB you can let a PCB manafacturer create it. I have designed a PCB at [EasyEDA](https://www.easyeda.com). You can find it here: <https://easyeda.com/Joennuh/Dice-Tower> The current design does not utilize extra pins from the MH-ET LIVE MiniKit ESP32 but the basic functionality works with both the Wemos D1 mini as the MH-ET LIVE MiniKit ESP32.
 
 From [EasyEDA](https://www.easyeda.com) you can easily send the Gerber files to [JLCPCB](https://www.jlcpcb.com) without the need to download and upload the Gerber files. Manufacturing the PCB already starts at $2,= and you nowadays can select several colors. I would advise to use black to keep in the theme of a dark Dice Tower with skull.
 
 I have no assocation to EasyEDA and JLCPCB and thus this explanation is not sponsored by EasyEDA nor JLCPCB.
 
 ### Development board
-The heart of the machine is the Wemos D1 mini. Theoretically any Arduino campatible development board can drive the project but since I have quite a few Wemos D1 mini's lying around I decided to go with that board. Currently the project doesn't use the WiFi capability of the Wemos D1 mini but the advantage of the choice to use this board is that WiFi functions can be added easily later on.
+The heart of the machine is the Wemos D1 mini or the MH-ET LIVE MiniKit ESP32. Theoretically any Arduino campatible development board can drive the project but since I had quite a few Wemos D1 mini's lying around I decided to go with that board. Later on the MH-ET LIVE MiniKit ESP32 got my interest since it has the same pin layout and added support for this board to the project. Currently the project doesn't use the WiFi capability of the Wemos D1 mini and MH-ET LIVE MiniKit ESP32 but the advantage of the choice to use these 2 boards is that WiFi functions can be added easily later on.
 
 ### Leds and resistors
 As long that you do not exceed the following limits you can use any led:
 - Maxmimum 3.3V, 12 mA for the leds driven by the Wemos D1 mini (eyes, campfire and configuration/status led).
-- Maxmimum 3.3V for the power led (not driven by GPIO but still the 3.3V power of the Wemos D1 mini).
+- Maxmimum 3.3V, 40 mA for the leds driven by the MH-ET LIVE MiniKit ESP32 (eyes, campfire and configuration/status led)
+- Maxmimum 3.3V for the power led (not driven by GPIO but still uses the 3.3V power of the Wemos D1 mini / MH-ET LIVE MiniKit ESP32).
 - Maxmimum 5V for any other led.
 
 As far as we found the data for it we do use the leds and resistors in the table below. We also specify to which power line it will be connected. On our prototype PCB we did use SMD leds for the continous power led and configuration led with other characteristics and thus we also used other resistors. Please see our [Prototype PCB Wiki page](https://github.com/Joennuh/Dice-Tower/wiki/Prototype-PCB) for that.
@@ -59,7 +61,7 @@ As far as we found the data for it we do use the leds and resistors in the table
 Any button could do but for the PCB I have chosen for a sidewards 6 x 6 mm tactile button. Any depth of the button could do but I use the default one of 5 mm.
 
 ### Trigger
-The trigger provides a signal to the D3 pin of the Wemos D1 mini when a dice rolling through the tube of the Dice Tower has been detected. The trigger can be a anything that shorts the D3 pin of the Wemos D1 mini to ground. This could be for example 2 pieces of aluminium hitting each other when a dice rolls on it. Me and my friend choose to use a SW-18010P vibration sensor to sens the vibration fot the dice through the tube. It's best to attach the vibration sensor on the outside of the tube somehwere on the almost the end of the tube. It is also best to leave some space around the end of the tube so that the tube can vibrate enough to let the vibration sensor detect vibrations.
+The trigger provides a signal to the D3 pin of the Wemos D1 mini or GPIO 17 pin of the MH-ET LIVE MiniKit ESP32 when a dice rolling through the tube of the Dice Tower has been detected. The trigger can be a anything that shorts the D3 pin of the Wemos D1 mini or GPIO 17 pin of the MH-ET LIVE MiniKit ESP32 to ground. This could be for example 2 pieces of aluminium hitting each other when a dice rolls on it. Me and my friend choose to use a SW-18010P vibration sensor to sens the vibration fot the dice through the tube. It's best to attach the vibration sensor on the outside of the tube somehwere on the almost the end of the tube. It is also best to leave some space around the end of the tube so that the tube can vibrate enough to let the vibration sensor detect vibrations.
 
 ### Header pins
 There are several ways to connect all leds to the mainboard but on the PCB I designed have been decided in a way that you can choose to use pin headers (female or male). In that case you need a double row header. I would advise an easily breakable female double row header.
@@ -75,13 +77,13 @@ Ofcourse you also will need a micro-USB cable to power the board through the Wem
 To protect the leads of the leds it is advisble to use some heatshrink tubes around the exposed leads. This is to prevent any accidental shortage.
 
 ## Software
-The software can be downloaded from this Github repository under the GPL 3.0 license. Currently the software doesn't use WiFi cpability of the Wemos D1 mini but this can be subject of change in the future.
+The software can be downloaded from this Github repository under the GPL 3.0 license. Currently the software doesn't use WiFi capability of the Wemos D1 mini / MH-ET LIVE MiniKit ESP32 but this can be subject of change in the future.
 
 ### Startup
-By default at startup all leds will go on and off one by one to test the leds. During this test the onboard led of the Wemos D1 mini will stay on.
+By default at startup all leds will go on and off one by one to test the leds. On the MH-ET LIVE MiniKit ESP32 the eye leds will go on together instead of individually during the startup fase. During startup the onboard led of the Wemos D1 mini / MH-ET LIVE MiniKit ESP32 will stay on.
 
 ### Default program
-After the selftest the yellow leds will start flickering at random intensity to simulate a campfire. The red leds of the eyes will stay lit permanently on a low intensity. When pin D3 of the Wemos D1 mini got HIGH the red leds will blink a few times and they stay on for about 2 seconds.
+After the selftest the yellow leds will start flickering at random intensity to simulate a campfire. The red leds of the eyes will stay lit permanently on a low intensity. When pin D3 of the Wemos D1 mini or GPIO 17 of the MH-ET LIVE MiniKit ESP32 got HIGH the red leds will blink a few times and they stay on for about 2 seconds. This can also be triggered by a short press on the configuration button which is connected to D5 on the Wemos D1 mini or GPIO 18 of the MH-ET LIVE MiniKit ESP32.
 
 ### Configuration button
 A short press on the configuration button will manually trigger the blinking red leds. The green configuration / status led will shortly blink to confirm the short press.


### PR DESCRIPTION
Added support for the MH-ET LIVE MiniKit ESP32 which has exactly the same pin layout as the Wemos D1 mini. It uses the ESP32 instead of the ESP8266. It also has additional pins which can drive more leds and buttons.